### PR TITLE
fix(todo-test): repoint ToDoTest at internal todo app, update locators

### DIFF
--- a/NUnitHyperTestDemo/Tests/NUnitToDoTest.cs
+++ b/NUnitHyperTestDemo/Tests/NUnitToDoTest.cs
@@ -125,26 +125,21 @@ namespace NUnitToDo
             _test = _extent!.CreateTest(context_name);
 
             Console.WriteLine("Navigating to todos app.");
-            driver.Value!.Navigate().GoToUrl("https://lambdatest.github.io/sample-todo-app/");
-
+            driver.Value!.Navigate().GoToUrl("https://ltqa-frontend.lambdatestinternal.com/sample-todo-app/");
+            var wait = new WebDriverWait(driver.Value, TimeSpan.FromSeconds(20));
+            wait.Until(d => d.FindElement(By.Name("li4")).Displayed);
             driver.Value.FindElement(By.Name("li4")).Click();
             Console.WriteLine("Clicking Checkbox");
             driver.Value.FindElement(By.Name("li5")).Click();
-
-            /* If both clicks worked, then the following List should have length 2 */
-            IList<IWebElement> elems = driver.Value.FindElements(By.ClassName("ng-not-empty"));
-
-            /* so we'll assert that this is correct. */
+            IList<IWebElement> elems = driver.Value.FindElements(By.CssSelector("input[type='checkbox']:checked"));
             Assert.That(elems.Count, Is.EqualTo(2));
-
             Console.WriteLine("Entering Text");
             driver.Value.FindElement(By.Id("sampletodotext")).SendKeys("Yey, Let's add it to list");
             driver.Value.FindElement(By.Id("addbutton")).Click();
-            var wait = new WebDriverWait(driver.Value, TimeSpan.FromSeconds(20));
             string expectedText = "Yey, Let's add it to list";
             var lastItem = wait.Until(d =>
             {
-                var items = d.FindElements(By.CssSelector("ul.list-unstyled li span.ng-binding"));
+                var items = d.FindElements(By.CssSelector("ul.list-unstyled li span[data-testid^='todo-text-']"));
                 if (items.Count == 0) return null;
                 var last = items[items.Count - 1];
                 return last.Text.Trim() == expectedText ? last : null;


### PR DESCRIPTION
## Problem

The HyperExecute job fails on the **`ToDoTest`** task (the `LoginTest` task passes). Root cause: `NUnitToDoTest.cs` navigates to `https://lambdatest.github.io/sample-todo-app/`, which now returns **HTTP 404**. The 404 page has no todo elements, so `driver.FindElement(By.Name("li4"))` throws `NoSuchElementException` — and it fails again after the configured auto-retry.

## Fix

Repoint `ToDoTest` to the internal todo app at `https://ltqa-frontend.lambdatestinternal.com/sample-todo-app/`. This is a **React** reimplementation (the old github.io app was Angular), so the locators are updated to the new DOM:

| Element | Old (Angular) | New (React) |
|---|---|---|
| Checkboxes | `name="li1..li5"` | unchanged |
| Text input / Add button | `#sampletodotext` / `#addbutton` | unchanged |
| List `<ul>` | `.list-unstyled` | unchanged |
| Checked marker | `.ng-not-empty` | native `input[type=checkbox]:checked` |
| Item text span | `span.ng-binding` | `span[data-testid^=todo-text-]` |

Also added a `WebDriverWait` for the SPA to render before the first interaction.

## Notes

- 5 default items, all unchecked initially — clicking `li4` + `li5` still yields exactly 2 checked, so the assertions are unchanged.
- DOM verified against the deployed app's JS bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)